### PR TITLE
PAM logfile opening error on Archlinux

### DIFF
--- a/src/auth_pam.c
+++ b/src/auth_pam.c
@@ -88,7 +88,7 @@ static int module_authenticate(const char *pass) {
     int retval;
 
     password = pass;
-    retval = pam_start("login", username, &conv, &pam_handle);
+    retval = pam_start("system-auth", username, &conv, &pam_handle);
 
     if (retval == PAM_SUCCESS)
         retval = pam_set_item(pam_handle, PAM_TTY, ttyname(0));


### PR DESCRIPTION
I've stumbled upon some errors when using alock with the pam mechanism in my Archlinux installation:

```
pam_tally(login:auth): Error opening /var/log/faillog for update
pam_tally(login:auth): Error opening /var/log/faillog for read
```

Those errors don't seem to impact any functionality but for the sake of fixing it I've found a similar bug report on the Archlinux bugtracker, about i3lock: https://bugs.archlinux.org/task/31544

Said bug report eventually helped me find a fix, which consists of using a different `service_name` and is included in this PR.

I've reported the issue downstream (https://aur.archlinux.org/packages/alock-git/) and it would be worth investigating if this modification is compatible with other deployments before applying it for everyone.