### PR TITLE
Fix gcc warning in utils.c

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -269,9 +269,9 @@ int alock_grayscale_image(XImage *image,
 
     union {
         struct __attribute__ ((packed)) {
-            uint8_t red   : 5;
-            uint8_t green : 6;
-            uint8_t blue  : 5;
+            uint16_t red   : 5;
+            uint16_t green : 6;
+            uint16_t blue  : 5;
         } v16;
         struct __attribute__ ((packed)) {
             uint8_t red;


### PR DESCRIPTION
GCC 7.3.0 reports

    utils.c:275:9: note: offset of packed bit-field ‘green’ has changed in GCC 4.4

because there could be padding between uint8_t on some targets prior to gcc 4.4 [1]. Switch to uint16_t so there will be no unintentional padding.

[1] https://www.gnu.org/software/gcc/gcc-4.4/changes.html