### PR TITLE
Fix getting the PAM file name

### DIFF
--- a/src/auth_pam.c
+++ b/src/auth_pam.c
@@ -126,7 +126,7 @@ static void module_loadargs(const char *args) {
         }
         if (strstr(arg, "service=") == arg) {
             free(service);
-            service = strdup(&arg[7]);
+            service = strdup(&arg[8]);
         }
     }
 


### PR DESCRIPTION
I wanted to use a custom file (`/etc/pam.d/alock`) through the command line (`./src/alock -auth pam:service=alock`) and realized the named pass to PAM was `=alock` instead of the intended `alock`.