### PR TITLE
implicit declaration of function crypt

### DIFF
--- a/src/auth_passwd.c
+++ b/src/auth_passwd.c
@@ -17,6 +17,7 @@
 #include "alock.h"
 
 #include <string.h>
+#include <crypt.h>
 #include <unistd.h>
 #include <errno.h>
 #include <grp.h>


### PR DESCRIPTION
Corrects compile time warnings within auth_password when calling crypt function

It looks like a commit from 10 years ago tried fixing this with "#define _XOPEN_SOURCE" ?

`auth_passwd.c: In function ‘module_authenticate’:`
`auth_passwd.c:73:19: warning: implicit declaration of function ‘crypt’ [-Wimplicit-function-declaration]`
`auth_passwd.c:73:19: warning: passing argument 1 of ‘strcmp’ makes pointer from integer without a cast [-Wint-conversion] 
In file included from auth_passwd.c:19:`
`/usr/include/string.h:137:32: note: expected ‘const char *’ but argument is of type ‘int’
  137 | extern int strcmp (const char *__s1, const char *__s2)
      |                    ~~~~~~~~~~~~^~~~`