### PR TITLE
mitigate SIGSEGV XFreeCursor from undef data.display

### DIFF
--- a/src/cursor_image.c
+++ b/src/cursor_image.c
@@ -73,6 +73,8 @@ static int module_init(Display *dpy) {
         unsigned int h = 0;
         Pixmap cursor_pm = None;
 
+        data.display = dpy;
+
 #if ENABLE_IMLIB2
         {
             Imlib_Image img;


### PR DESCRIPTION
When using -cursor image:file alock always exits with segfault.
data.display appears to be null within module_free() so assigning a value appears to resolve this for me.

`'Program received signal SIGSEGV, Segmentation fault.`
`0x00007ffff7e92a19 in XFreeCursor () from /usr/lib64/libX11.so.6`