### PR TITLE
Check crypt() value to avoid possible NULL ptr dereference

### DIFF
--- a/src/auth_passwd.c
+++ b/src/auth_passwd.c
@@ -65,13 +65,13 @@ static int module_init(Display *display) {
 }
 
 static int module_authenticate(const char *pass) {
+
     char *cpw;
 
     if (pass == NULL || pwd_entry == NULL)
         return -1;
 
     cpw = crypt(pass, pwd_entry->pw_passwd);
-
     if (cpw == NULL)
         return -1;
 

--- a/src/auth_passwd.c
+++ b/src/auth_passwd.c
@@ -65,13 +65,19 @@ static int module_init(Display *display) {
 }
 
 static int module_authenticate(const char *pass) {
+    char *cpw;
 
     if (pass == NULL || pwd_entry == NULL)
         return -1;
 
+    cpw = crypt(pass, pwd_entry->pw_passwd);
+
+    if (cpw == NULL)
+        return -1;
+
     /* Simpler, and should work with crypt() algorithms using longer
      * salt strings (like the md5-based one on freebsd).  --marekm */
-    return strcmp(crypt(pass, pwd_entry->pw_passwd), pwd_entry->pw_passwd);
+    return strcmp(cpw, pwd_entry->pw_passwd);
 }
 
 


### PR DESCRIPTION
I found this while debugging a segfault in another locker, along with the issue I described in https://github.com/Arkq/alock/pull/14#issuecomment-1229284687.

It's referenced in CVE-2013-4122, and all modern passwd-verification modules do this.

> Starting with glibc 2.17 (eglibc 2.17), crypt() fails with EINVAL
> (w/ NULL return) if the salt violates specifications. Additionally,
> on FIPS-140 enabled Linux systems, DES/MD5-encrypted passwords
> passed to crypt() fail with EPERM (w/ NULL return).
> 
> When using glibc's crypt(), check return value to avoid a possible
> NULL pointer dereference.