### PR TITLE
auth_pam: pass password via PAM conversation data, remove global state

### DIFF
--- a/src/auth_pam.c
+++ b/src/auth_pam.c
@@ -89,7 +89,7 @@ static int module_authenticate(const char *pass) {
     };
     int retval;
 
-    /* pass the password to the conversation via appdata_ptr; do not
+    /* Pass the password to the conversation via appdata_ptr. Do not
      * store it in a global variable. The `pass` buffer is owned by the
      * caller and is cleared by the caller after authentication. */
     conv.appdata_ptr = (void *)pass;

--- a/src/auth_pam.c
+++ b/src/auth_pam.c
@@ -47,10 +47,7 @@ static int alock_auth_pam_conv(int num_msg,
     for (i = 0; i < num_msg; i++) {
         switch (msgs[i]->msg_style) {
         case PAM_PROMPT_ECHO_OFF:
-            if (password)
-                (*response)[i].resp = strdup(password);
-            else
-                (*response)[i].resp = NULL;
+            (*response)[i].resp = password ? strdup(password) : NULL;
             (*response)[i].resp_retcode = 0;
             break;
         case PAM_ERROR_MSG:


### PR DESCRIPTION
Stop storing the authentication password in a global variable. Instead, pass the caller-owned password buffer to the PAM conversation function via pam_conv.appdata_ptr, as intended by the PAM API.

This reduces password lifetime and scope, avoids stale or dangling global
pointers, and improves correctness and security without changing authentication behavior.